### PR TITLE
Feat(auth): implemented a designated route for specific roles

### DIFF
--- a/resources/views/dashboard/barangay-official.blade.php
+++ b/resources/views/dashboard/barangay-official.blade.php
@@ -1,0 +1,4 @@
+<x-app-layout title="Dashboard">
+    <h1>{{__('Barangay Official Dashboard')}}</h1>
+    <p>{{__('User: ' . $user)}}</p>
+</x-app-layout>

--- a/resources/views/dashboard/bhw.blade.php
+++ b/resources/views/dashboard/bhw.blade.php
@@ -1,0 +1,4 @@
+<x-app-layout title="Dashboard">
+    <h1>{{__('BHW Dashboard')}}</h1>
+    <p>{{__('User: ' . $user)}}</p>
+</x-app-layout>

--- a/resources/views/dashboard/doctor.blade.php
+++ b/resources/views/dashboard/doctor.blade.php
@@ -1,0 +1,4 @@
+<x-app-layout title="Dashboard">
+    <h1>{{__('Doctor Dashboard')}}</h1>
+    <p>{{__('User: ' . $user)}}</p>
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,38 @@ Route::middleware(['auth'])->group(function(){
    Route::get('/email/verify', function(){
          return view('auth.verify-email');
     })->name('verification.notice');
-
    Route::post('/email/send-verification', [EmailVerificationController::class, 'store'])->name('verification.send');
+});
+
+Route::middleware([
+    'auth:sanctum',
+    config('jetstream.auth_session'),
+    'verified',
+    'role:barangay-official',
+])->group(function () {
+    Route::get('/dashboard/barangay-official', function(){
+        return view('dashboard.barangay-official', ['user' => auth()->user()]);
+    })->name('dashboard.barangay-official');
+});
+
+Route::middleware([
+    'auth:sanctum',
+    config('jetstream.auth_session'),
+    'verified',
+    'role:bhw',
+])->group(function () {
+    Route::get('/dashboard/bhw', function(){
+        return view('dashboard.bhw', ['user' => auth()->user()]);
+    })->name('dashboard.bhw');
+});
+
+Route::middleware([
+    'auth:sanctum',
+    config('jetstream.auth_session'),
+    'verified',
+    'role:doctor',
+])->group(function () {
+    Route::get('/dashboard/doctor', function(){
+        return view('dashboard.doctor', ['user' => auth()->user()]);
+    })->name('dashboard.doctor');
 });


### PR DESCRIPTION
Added routes for Barangay Official, BHW, and Doctor dashboards.

Test passed: 3 out of 3
- Barangay Officials can access their dashboard
- BHW can access their dashboard
- Doctor can access their dashboard.

Possible refactor:
- Add a controller and middleware to centralize the role validation and give access to their designated routes.