### PR TITLE
Test(auth): added role-based access feature test for every core functionality

### DIFF
--- a/tests/Feature/Auth/UserRoleTest.php
+++ b/tests/Feature/Auth/UserRoleTest.php
@@ -159,4 +159,332 @@ class UserRoleTest extends TestCase
 
         $response->assertRedirect('/doctor/dashboard');
     }
+
+    public function test_barangay_officials_can_access_user_management(): void
+    {
+        $user = User::factory()->withRole($this->roles[0])->create();
+
+        $response = $this->actingAs($user)->get('/barangay-official/users');
+
+        $response->assertStatus(200)
+            ->assertViewIs('barangay-official.user-accounts')
+            ->assertSee('User Accounts');
+    }
+
+    public function test_barangay_officials_can_access_audit_trail(): void
+    {
+        $user = User::factory()->withRole($this->roles[0])->create();
+
+        $response = $this->actingAs($user)->get('/barangay-official/audit-trail');
+
+        $response->assertStatus(200)
+            ->assertViewIs('barangay-official.audit-trail')
+            ->assertSee('Audit Trail');
+    }
+
+    public function test_barangay_officials_can_access_patient_records(): void
+    {
+        $user = User::factory()->withRole($this->roles[0])->create();
+
+        $response = $this->actingAs($user)->get('/patients');
+
+        $response->assertStatus(200)
+            ->assertViewIs('patient-records.index')
+            ->assertSee('Patient Records');
+    }
+
+    public function test_barangay_officials_can_access_medicine_inventory(): void
+    {
+        $user = User::factory()->withRole($this->roles[0])->create();
+
+        $response = $this->actingAs($user)->get('/medicines');
+
+        $response->assertStatus(200)
+            ->assertViewIs('medicine-inventory.index')
+            ->assertSee('Medicine Inventory');
+    }
+
+    public function test_barangay_officials_can_access_scheduling(): void
+    {
+        $user = User::factory()->withRole($this->roles[0])->create();
+
+        $response = $this->actingAs($user)->get('/scheduling');
+
+        $response->assertStatus(200)
+            ->assertViewIs('scheduling.index')
+            ->assertSee('Scheduling');
+    }
+
+    public function test_barangay_officials_can_access_tb_prediction(): void
+    {
+        $user = User::factory()->withRole($this->roles[0])->create();
+
+        $response = $this->actingAs($user)->get('/tb-prediction');
+
+        $response->assertStatus(200)
+            ->assertViewIs('tb-prediction.index')
+            ->assertSee('TB Prediction');
+    }
+
+    public function test_barangay_officials_can_access_disease_demographics(): void
+    {
+        $user = User::factory()->withRole($this->roles[0])->create();
+
+        $response = $this->actingAs($user)->get('/disease-demographics');
+
+        $response->assertStatus(200)
+            ->assertViewIs('disease-demographics.index')
+            ->assertSee('Disease Demographics');
+    }
+
+    public function test_barangay_officials_can_access_health_records(): void
+    {
+        $user = User::factory()->withRole($this->roles[0])->create();
+
+        $response = $this->actingAs($user)->get('/health-records');
+
+        $response->assertStatus(200)
+            ->assertViewIs('health-records.index')
+            ->assertSee('Health Records');
+    }
+
+    public function test_bhw_can_access_patient_records(): void
+    {
+        $user = User::factory()->withRole($this->roles[1])->create();
+
+        $response = $this->actingAs($user)->get('/patients');
+
+        $response->assertStatus(200)
+            ->assertViewIs('patient-records.index')
+            ->assertSee('Patient Records');
+    }
+
+    public function test_bhw_can_access_medicine_inventory(): void
+    {
+        $user = User::factory()->withRole($this->roles[1])->create();
+
+        $response = $this->actingAs($user)->get('/medicines');
+
+        $response->assertStatus(200)
+            ->assertViewIs('medicine-inventory.index')
+            ->assertSee('Medicine Inventory');
+    }
+
+    public function test_bhw_can_access_scheduling(): void
+    {
+        $user = User::factory()->withRole($this->roles[1])->create();
+
+        $response = $this->actingAs($user)->get('/scheduling');
+
+        $response->assertStatus(200)
+            ->assertViewIs('scheduling.index')
+            ->assertSee('Scheduling');
+    }
+
+    public function test_bhw_can_access_tb_prediction(): void
+    {
+        $user = User::factory()->withRole($this->roles[1])->create();
+
+        $response = $this->actingAs($user)->get('/tb-prediction');
+
+        $response->assertStatus(200)
+            ->assertViewIs('tb-prediction.index')
+            ->assertSee('TB Prediction');
+    }
+
+    public function test_bhw_can_access_disease_demographics(): void
+    {
+        $user = User::factory()->withRole($this->roles[1])->create();
+
+        $response = $this->actingAs($user)->get('/disease-demographics');
+
+        $response->assertStatus(200)
+            ->assertViewIs('disease-demographics.index')
+            ->assertSee('Disease Demographics');
+    }
+
+    public function test_bhw_can_access_health_records(): void
+    {
+        $user = User::factory()->withRole($this->roles[1])->create();
+
+        $response = $this->actingAs($user)->get('/health-records');
+
+        $response->assertStatus(200)
+            ->assertViewIs('health-records.index')
+            ->assertSee('Health Records');
+    }
+
+    public function test_doctor_can_access_patient_records(): void
+    {
+        $user = User::factory()->withRole($this->roles[2])->create();
+
+        $response = $this->actingAs($user)->get('/patients');
+
+        $response->assertStatus(200)
+            ->assertViewIs('patient-records.index')
+            ->assertSee('Patient Records');
+    }
+
+    public function test_doctor_can_access_medicine_inventory(): void
+    {
+        $user = User::factory()->withRole($this->roles[2])->create();
+
+        $response = $this->actingAs($user)->get('/medicines');
+
+        $response->assertStatus(200)
+            ->assertViewIs('medicine-inventory.index')
+            ->assertSee('Medicine Inventory');
+    }
+
+    public function test_doctor_can_access_scheduling(): void
+    {
+        $user = User::factory()->withRole($this->roles[2])->create();
+
+        $response = $this->actingAs($user)->get('/scheduling');
+
+        $response->assertStatus(200)
+            ->assertViewIs('scheduling.index')
+            ->assertSee('Scheduling');
+    }
+
+    public function test_doctor_can_access_tb_prediction(): void
+    {
+        $user = User::factory()->withRole($this->roles[2])->create();
+
+        $response = $this->actingAs($user)->get('/tb-prediction');
+
+        $response->assertStatus(200)
+            ->assertViewIs('tb-prediction.index')
+            ->assertSee('TB Prediction');
+    }
+
+    public function test_doctor_can_access_disease_demographics(): void
+    {
+        $user = User::factory()->withRole($this->roles[2])->create();
+
+        $response = $this->actingAs($user)->get('/disease-demographics');
+
+        $response->assertStatus(200)
+            ->assertViewIs('disease-demographics.index')
+            ->assertSee('Disease Demographics');
+    }
+
+    public function test_doctor_can_access_health_records(): void
+    {
+        $user = User::factory()->withRole($this->roles[2])->create();
+
+        $response = $this->actingAs($user)->get('/health-records');
+
+        $response->assertStatus(200)
+            ->assertViewIs('health-records.index')
+            ->assertSee('Health Records');
+    }
+
+    public function test_unauthorized_users_cannot_access_user_management(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/barangay-official/users');
+
+        $response->assertForbidden();
+    }
+
+    public function test_unauthorized_users_cannot_access_audit_trail(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/barangay-official/audit-trail');
+
+        $response->assertForbidden();
+    }
+
+    public function test_unauthorized_users_cannot_access_patient_records(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/patients');
+
+        $response->assertForbidden();
+    }
+
+    public function test_unauthorized_users_cannot_access_medicine_inventory(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/medicines');
+
+        $response->assertForbidden();
+    }
+
+    public function test_unauthorized_users_cannot_access_scheduling(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/scheduling');
+
+        $response->assertForbidden();
+    }
+
+    public function test_unauthorized_users_cannot_access_tb_prediction(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/tb-prediction');
+
+        $response->assertForbidden();
+    }
+
+    public function test_unauthorized_users_cannot_access_disease_demographics(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/disease-demographics');
+
+        $response->assertForbidden();
+    }
+
+    public function test_unauthorized_users_cannot_access_health_records(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get('/health-records');
+
+        $response->assertForbidden();
+    }
+
+    public function test_bhw_cannot_access_user_management(): void
+    {
+        $user = User::factory()->withRole($this->roles[1])->create();
+
+        $response = $this->actingAs($user)->get('/barangay-official/users');
+
+        $response->assertForbidden();
+    }
+
+    public function test_bhw_cannot_access_audit_trail(): void
+    {
+        $user = User::factory()->withRole($this->roles[1])->create();
+
+        $response = $this->actingAs($user)->get('/barangay-official/audit-trail');
+
+        $response->assertForbidden();
+    }
+
+    public function test_doctor_cannot_access_user_management(): void
+    {
+        $user = User::factory()->withRole($this->roles[2])->create();
+
+        $response = $this->actingAs($user)->get('/barangay-official/users');
+
+        $response->assertForbidden();
+    }
+
+    public function test_doctor_cannot_access_audit_trail(): void
+    {
+        $user = User::factory()->withRole($this->roles[2])->create();
+
+        $response = $this->actingAs($user)->get('/barangay-official/audit-trail');
+
+        $response->assertForbidden();
+    }
 }


### PR DESCRIPTION
Added tests to evaluate the role-based access per core functionality.

Tests:
- test_barangay_officials_can_access_user_management
- test_barangay_officials_can_access_audit_trail
- test_barangay_officials_can_access_patient_records
- test_barangay_officials_can_access_medicine_inventory
- test_barangay_officials_can_access_scheduling
- test_barangay_officials_can_access_tb_prediction
- test_barangay_officials_can_access_disease_demographics
- test_barangay_officials_can_access_health_records
- test_bhw_can_access_patient_records
- test_bhw_can_access_medicine_inventory
- test_bhw_can_access_scheduling
- test_bhw_can_access_tb_prediction
- test_bhw_can_access_disease_demographics
- test_bhw_can_access_health_records
- test_doctor_can_access_patient_records
- test_doctor_can_access_medicine_inventory
- test_doctor_can_access_scheduling
- test_doctor_can_access_tb_prediction
- test_doctor_can_access_disease_demographics
- test_doctor_can_access_health_records
- test_unauthorized_users_cannot_access_user_management
- test_unauthorized_users_cannot_access_audit_trail
- test_unauthorized_users_cannot_access_patient_records
- test_unauthorized_users_cannot_access_medicine_inventory
- test_unauthorized_users_cannot_access_scheduling
- test_unauthorized_users_cannot_access_tb_prediction
- test_unauthorized_users_cannot_access_disease_demographics
- test_unauthorized_users_cannot_access_health_records
- test_bhw_cannot_access_user_management
- test_bhw_cannot_access_audit_trail
- test_doctor_cannot_access_user_management
- test_doctor_cannot_access_audit_trail